### PR TITLE
Fix spark machine features

### DIFF
--- a/conf/machine/include/spark.inc
+++ b/conf/machine/include/spark.inc
@@ -24,6 +24,6 @@ EXTRA_IMAGEDEPENDS += "\
     libstgles \
     "
 
-MACHINE_FEATURES += "hdmicec ci directfb sh4booster modutils-spark"
+MACHINE_FEATURES += "hdmicec ci directfb sh4booster modutils-spark textlcd 7segment"
 
 DISTRO_FEATURES_append += "gtk-directfb"

--- a/conf/machine/spark.conf
+++ b/conf/machine/spark.conf
@@ -8,7 +8,6 @@ SOC_FAMILY = "sti7111"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
 	stlinux24-sh4-stx7111-fdma-firmware \
 	stlinux24-sh4-stmfb-firmware-stx7111 \
-        enigma2-plugin-extensions-sparkvfd \
 "
 
 MACHINE_FEATURES += "spark"

--- a/conf/machine/spark7162.conf
+++ b/conf/machine/spark7162.conf
@@ -9,7 +9,6 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "\
     stlinux24-sh4-stx7105-fdma-firmware \
     stlinux24-sh4-stmfb-firmware-stx7105 \
     enigma2-plugin-systemplugins-sparkuniontunertype \
-    enigma2-plugin-extensions-spark7162vfd \
 "
 
 MACHINE_FEATURES += "tripletuner spark7162"


### PR DESCRIPTION
https://github.com/OpenVisionE2/meta-sh4/commit/23e861565d0e14cca78a10f53294edc3de26c420 is wrong because some parts of enigma2 check machine features via configure.ac and do some core changes so you need to be sure about this then remove a machine feature.

This is the solution: https://github.com/OpenVisionE2/openvision-development-platform/commit/697c14a4b3dc7d12ccee8be5c78075ee135b86c7